### PR TITLE
Adds download counter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Downloads](https://img.shields.io/endpoint?url=https://openbeans.org/plugin-counter/api/116)
+
 # Overview
 Plugin for NetBans IDE that provides an alternative implementation of the built-in "Navigator" view. The plugin works exclusively with Java source files. It displays a pop-up window showing the structure of the file - a tree view of members, methods, and other classes. And allows for searching and quick navigation to a selected member.
 


### PR DESCRIPTION
This PR adds a download counter badge to the README using the [netbeans-download-badges](https://github.com/emilianbold/netbeans-download-badges) service.

Changes

Added download counter badge to README.md

Notes
The badge displays the total number of downloads for this plugin from the NetBeans Plugin Portal. The counter is provided by openbeans.org and updates automatically.